### PR TITLE
Add option to set autoPadding parameter

### DIFF
--- a/lib/file-encryptor.js
+++ b/lib/file-encryptor.js
@@ -17,6 +17,7 @@ Encryptor.encryptFile = function(inputPath, outputPath, key, options, callback) 
   var inputStream = fs.createReadStream(inputPath);
   var outputStream = fs.createWriteStream(outputPath);
   var cipher = crypto.createCipher(options.algorithm, keyBuf);
+  cipher.setAutoPadding(options.autoPadding);
 
   inputStream.on('data', function(data) {
     var buf = new Buffer(cipher.update(data), 'binary');
@@ -52,6 +53,7 @@ Encryptor.decryptFile = function(inputPath, outputPath, key, options, callback) 
   var inputStream = fs.createReadStream(inputPath);
   var outputStream = fs.createWriteStream(outputPath);
   var cipher = crypto.createDecipher(options.algorithm, keyBuf);
+  cipher.setAutoPadding(options.autoPadding);
 
   inputStream.on('data', function(data) {
     var buf = new Buffer(cipher.update(data), 'binary');
@@ -87,7 +89,8 @@ Encryptor.combineOptions = function(options) {
 };
 
 Encryptor.defaultOptions = {
-  algorithm: 'aes192'
+  algorithm: 'aes192',
+  autoPadding: true
 };
 
 module.exports = Encryptor;


### PR DESCRIPTION
If encrypted file is corrupt the autoPadding parameter won't allow decryption.
Had to set it to false in order to decrypt one of my files.